### PR TITLE
Feature/break up distlib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ yarn.lock
 .vscode
 dist
 distServer
+lib

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chili-publish/publisher-connector",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "author": "chili-publish",
   "description": "PublisherConnector is a class object that allows you to interact with the CHILI Publisher editorObject via postMessage without the complexity of postMessage.",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
   },
   "license": "MIT",
   "source": "./src/PublisherConnector.ts",
-  "main": "./dist/PublisherConnector.js",
-  "types": "./dist/PublisherConnector.d.ts",
-  "wrapper": "./dist/chiliInternalWrapper.js",
+  "main": "./lib/PublisherConnector.js",
+  "types": "./lib/PublisherConnector.d.ts",
+  "web-wrapper": "./dist/chiliInternalWrapper.min.js",
+  "web-connector": "./dist/PublisherConnector.min.js",
   "targets": {
     "main": {
       "sourceMap": false
@@ -19,7 +20,7 @@
     "types": {
       "sourceMap": false
     },
-    "wrapper": {
+    "web-wrapper": {
       "context": "browser",
       "engines": {
         "browsers": "last 2 Chrome version, last 2 Firefox version, last 2 Safari version, last 2 Edge version"
@@ -27,10 +28,21 @@
       "outputFormat": "global",
       "includeNodeModules": true,
       "source": "./onServer/chiliInternalWrapper.ts"
+    },
+    "web-connector": {
+      "context": "browser",
+      "outputFormat": "global",
+      "engines": {
+        "browsers": "last 2 Chrome version, last 2 Firefox version, last 2 Safari version, last 2 Edge version"
+      },
+      "optimize": true,
+      "includeNodeModules": true,
+      "scopeHoist": false
     }
   },
   "files": [
-    "dist/**"
+    "dist/**",
+    "lib/**"
   ],
   "devDependencies": {
     "@parcel/packager-ts": "2.5.0",


### PR DESCRIPTION
Chat with @brapoprod  to take his pull request a step further and break up the distribution into /dist and /lib folder. Also to change the name of /dist folders with ".min" to signify that they are minified and ready for production.

Also bumped version from 0.1.2 to 0.2.0 because the movement of PublisherConnector.js from /dist to /lib could cause a breaking change if someone (I don't know who) referenced this file directly.

@brapoprod - you already approved in person, but please review and merge in to your RP.

I tested all the files manually. For the PublisherConnector.min.js you need import it like so:
```javascript
import {PublisherConnector} from "../PublisherConnector.min.js"

const iframe = document.getElementById("editor-iframe");

(async () => {

    console.log(PublisherConnector);

    const publisherConnector = await PublisherConnector.build(iframe);
    window.publisherConnector = publisherConnector;
    const documentName = await publisherConnector.getObject("document.name");
    console.log(documentName);
})();
``` 

In  addition, you need to bring in your JS file as type="module"
```
<script type="module" src="./src/index.js"></script>
```

Finally, on the Parcel config to make PublisherConnector.js I had to set `"scopeHoist": false` otherwise the name of the class would be loss. If anyone knows how to tell Parcel to ignore certain scope names in scope hoisting, make a PR and teach me something.